### PR TITLE
Optimize quickhull and hybridize more

### DIFF
--- a/bench/quickhull/futhark/quickhull.fut
+++ b/bench/quickhull/futhark/quickhull.fut
@@ -130,6 +130,9 @@ module mk_quickhull (S : euclidean_space) = {
        in extract_empty_segments hull segs' points')
       |> (.0)
 
+  def filter_then_semihull (start : point) (end : point) (points : []point) =
+    semihull start end (filter (\p -> dist_less zero_dist (signed_dist_to_line start end p)) points)
+
   def pmin p q = if point_less p q then p else q
   def pmax p q = if point_less p q then q else p
 
@@ -161,6 +164,15 @@ entry semihull points l r idxs =
   in naive_quickhull.semihull start end (map p idxs)
      |> map (.1)
      |> filter (!=l) -- Remove starting point.
+
+-- select points above the line (l, r) and then compute the semihull of these
+entry top_level_filter_then_semihull points (l: i32) (r : i32) : []i32 =
+  let p i = ({x=points[i,0], y=points[i,1]}, i32.i64 i)
+  let start = p (i64.i32 l)
+  let end = p (i64.i32 r)
+  in naive_quickhull.filter_then_semihull start end (map p (indices points))
+     |> map (.1)
+     |> filter (!=l)
 
 entry quickhull [k] (ps : [k][2]f64) : []i32 =
   let ps' = map2 (\i p -> ({x=f64.f64 p[0], y=f64.f64 p[1]}, i32.i64 i))

--- a/bench/quickhull/futhark/quickhull.fut
+++ b/bench/quickhull/futhark/quickhull.fut
@@ -136,6 +136,9 @@ module mk_quickhull (S : euclidean_space) = {
   def pmin p q = if point_less p q then p else q
   def pmax p q = if point_less p q then q else p
 
+  def min_max_point ps =
+    (reduce pmin ps[0] ps, reduce pmax ps[0] ps)
+
   def compute (ps : []point) =
     if length ps <= 3 then (ps, []) else
     let leftmost = reduce pmin ps[0] ps
@@ -164,6 +167,12 @@ entry semihull points l r idxs =
   in naive_quickhull.semihull start end (map p idxs)
      |> map (.1)
      |> filter (!=l) -- Remove starting point.
+
+entry min_max_point_in_range [k] (points: [k][2]f64) lo hi : (i64, i64) =
+  let ps = take (hi-lo) (drop lo points)
+  let ps = map2 (\i p -> ({x=f64.f64 p[0], y=f64.f64 p[1]}, i32.i64 (lo + i))) (indices ps) ps
+  let (min, max) = naive_quickhull.min_max_point ps
+  in (i64.i32 min.1, i64.i32 max.1)
 
 -- select points above the line (l, r) and then compute the semihull of these
 entry top_level_filter_then_semihull points (l: i32) (r : i32) : []i32 =

--- a/bench/quickhull/main.mlb
+++ b/bench/quickhull/main.mlb
@@ -2,6 +2,7 @@
 futhark/quickhull.sig
 futhark/quickhull.sml
 
+sml/FlatPointSeq.sml
 sml/ParseFile.sml
 sml/Split.sml
 sml/TreeSeq.sml

--- a/bench/quickhull/main.sml
+++ b/bench/quickhull/main.sml
@@ -36,7 +36,9 @@ fun quickhullCPU points =
 
 fun semihullGPU points_fut (idxs, l, r) =
   let
-    val idxs' = Array.tabulate (Seq.length idxs, Int32.fromInt o Seq.nth idxs)
+    val idxs' = SeqBasis.tabulate 5000 (0, Seq.length idxs)
+      (Int32.fromInt o Seq.nth idxs)
+    (* val idxs' = Array.tabulate (Seq.length idxs, Int32.fromInt o Seq.nth idxs) *)
     val idxs_fut =
       Futhark.Int32Array1.new ctx (ArraySlice.full idxs') (Seq.length idxs)
     val res_fut =
@@ -86,4 +88,4 @@ val result = Benchmark.run ("quickhull " ^ impl) bench
 val () = Futhark.Real64Array2.free points_fut
 val () = Futhark.Context.free ctx
 val () = print
-  ("Points in convex hull: " ^ Int.toString (Seq.length result)^ "\n")
+  ("Points in convex hull: " ^ Int.toString (Seq.length result) ^ "\n")

--- a/bench/quickhull/sml/FlatPointSeq.sml
+++ b/bench/quickhull/sml/FlatPointSeq.sml
@@ -1,0 +1,38 @@
+structure FlatPointSeq:
+sig
+  type t
+
+  val fromArraySeq: (real * real) Seq.t -> t
+  val toArraySeq: t -> (real * real) Seq.t
+
+  val length: t -> int
+  val nth: t -> int -> (real * real)
+
+  val viewData: t -> real Seq.t
+end =
+struct
+
+  type t = real Seq.t (* of twice the length *)
+
+  fun fromArraySeq s =
+    let
+      val n = Seq.length s
+      val result = ForkJoin.alloc (2 * n)
+    in
+      ForkJoin.parfor 5000 (0, n) (fn i =>
+        let val (x, y) = Seq.nth s i
+        in Array.update (result, 2 * i, x); Array.update (result, 2 * i + 1, y)
+        end);
+      ArraySlice.full result
+    end
+
+
+  fun nth fs i =
+    (Seq.nth fs (2 * i), Seq.nth fs (2 * i + 1))
+  fun length fs = Seq.length fs div 2
+
+  fun toArraySeq fs =
+    Seq.tabulate (nth fs) (length fs)
+
+  fun viewData x = x
+end

--- a/bench/quickhull/sml/Quickhull.sml
+++ b/bench/quickhull/sml/Quickhull.sml
@@ -11,6 +11,16 @@ struct
   structure G = Geometry2D
   structure Tree = TreeSeq
 
+  fun startTiming () = Time.now ()
+
+  fun tick tm msg =
+    let
+      val tm' = Time.now ()
+    in
+      print ("tick: " ^ msg ^ ": " ^ Time.fmt 4 (Time.- (tm', tm)) ^ "s\n");
+      tm'
+    end
+
   fun hull hybrid doGpu pts =
     let
       fun pt i = Seq.nth pts i
@@ -21,65 +31,98 @@ struct
       fun x i =
         #1 (pt i)
       fun min_by f x y =
-          if f x < f y then x else y
+        if f x < f y then x else y
       fun max_by f x y =
-          if f x > f y then x else y
+        if f x > f y then x else y
 
       fun aboveLine p q i =
         (dist p q i > 0.0)
 
       fun parHull idxs l r =
-        let
-          fun doCpu () =
-            let
-              val lp = pt l
-              val rp = pt r
-              fun d i =
-                dist lp rp i
-              (* val idxs = DS.fromArraySeq idxs *)
+        if Seq.length idxs < 2 then
+          Tree.fromArraySeq idxs
+        else
+          let
+            val lp = pt l
+            val rp = pt r
+            fun d i =
+              dist lp rp i
+            (* val idxs = DS.fromArraySeq idxs *)
 
-              val (mid, _) =
-                SeqBasis.reduce 10000 max (~1, Real.negInf) (0, Seq.length idxs)
-                  (fn i => (Seq.nth idxs i, d (Seq.nth idxs i)))
-              (* val distances = DS.map (fn i => (i, d i)) idxs
-              val (mid, _) = DS.reduce max (~1, Real.negInf) distances *)
+            val (mid, _) =
+              SeqBasis.reduce 5000 max (~1, Real.negInf) (0, Seq.length idxs)
+                (fn i => (Seq.nth idxs i, d (Seq.nth idxs i)))
+            (* val distances = DS.map (fn i => (i, d i)) idxs
+            val (mid, _) = DS.reduce max (~1, Real.negInf) distances *)
 
-              val midp = pt mid
+            val midp = pt mid
 
-              fun flag i =
-                if aboveLine lp midp i then Split.Left
-                else if aboveLine midp rp i then Split.Right
-                else Split.Throwaway
-              val (left, right) = Split.parSplit idxs (Seq.map flag idxs)
-              (* (DS.force (DS.map flag idxs)) *)
+            fun flag i =
+              if aboveLine lp midp i then Split.Left
+              else if aboveLine midp rp i then Split.Right
+              else Split.Throwaway
+            (* val (left, right) = Split.parSplit idxs (Seq.map flag idxs) *)
+            (* (DS.force (DS.map flag idxs)) *)
 
-              fun doLeft () =
-                parHull left l mid
-              fun doRight () =
-                parHull right mid r
-              val (leftHull, rightHull) =
-                if Seq.length left + Seq.length right <= 2048 then
-                  (doLeft (), doRight ())
-                else
-                  ForkJoin.par (doLeft, doRight)
-            in
-              Tree.append (leftHull, (Tree.append (Tree.$ mid, rightHull)))
-            end
-        in
-          if Seq.length idxs < 2 then
-            Tree.fromArraySeq idxs
-          (* if DS.length idxs <= 2048 then
-             seqHull idxs l r *)
-          else if hybrid then
-            ForkJoin.choice
-              { prefer_cpu = doCpu
-              , prefer_gpu = fn () => Tree.fromArraySeq (doGpu (idxs, l, r))
-              }
-          else
-            doCpu ()
-        end
+            fun flag i =
+              if aboveLine lp midp i then 0w0
+              else if aboveLine midp rp i then 0w1
+              else 0w2
 
-      (* val tm = Util.startTiming () *)
+            val flags = Seq.map flag idxs
+
+            val (left, right) =
+              ForkJoin.par
+                ( fn _ =>
+                    ArraySlice.full
+                      (SeqBasis.filter 2000 (0, Seq.length idxs) (Seq.nth idxs)
+                         (fn i => Seq.nth flags i = 0w0))
+                , fn _ =>
+                    ArraySlice.full
+                      (SeqBasis.filter 2000 (0, Seq.length idxs) (Seq.nth idxs)
+                         (fn i => Seq.nth flags i = 0w1))
+                )
+
+            fun doLeft () =
+              parHull_choose left l mid
+            fun doRight () =
+              parHull right mid r
+            val (leftHull, rightHull) =
+              if Seq.length left + Seq.length right <= 1000 then
+                (doLeft (), doRight ())
+              else
+                ForkJoin.par (doLeft, doRight)
+          in
+            Tree.append (leftHull, (Tree.append (Tree.$ mid, rightHull)))
+          end
+
+
+      and parHull_choose idxs l r =
+        if not hybrid orelse Seq.length idxs < 1000 then
+          parHull idxs l r
+        else
+          ForkJoin.choice
+            { prefer_cpu = fn () => parHull idxs l r
+            , prefer_gpu = fn () => Tree.fromArraySeq (doGpu (idxs, l, r))
+            }
+
+      (*
+      in
+        if Seq.length idxs < 2 then
+          Tree.fromArraySeq idxs
+        (* if DS.length idxs <= 2048 then
+           seqHull idxs l r *)
+        else if hybrid then
+          ForkJoin.choice
+            { prefer_cpu = doCpu
+            , prefer_gpu = fn () => Tree.fromArraySeq (doGpu (idxs, l, r))
+            }
+        else
+          doCpu ()
+      end
+      *)
+
+      val tm = startTiming ()
 
       (* val allIdx = DS.tabulate (fn i => i) (Seq.length pts) *)
 
@@ -92,12 +135,11 @@ struct
         (DS.map (fn i => (i, i)) allIdx) *)
 
       val (l, r) =
-        SeqBasis.reduce 10000
-          (fn ((l1, r1), (l2, r2)) =>
-             (min_by x l1 l2, max_by x r1 r2))
-          (0, 0) (0, Seq.length pts) (fn i => (i, i))
+        SeqBasis.reduce 5000
+          (fn ((l1, r1), (l2, r2)) => (min_by x l1 l2, max_by x r1 r2)) (0, 0)
+          (0, Seq.length pts) (fn i => (i, i))
 
-      (* val tm = Util.tick tm "endpoints" *)
+      val tm = tick tm "endpoints"
 
       val lp = pt l
       val rp = pt r
@@ -110,24 +152,63 @@ struct
           else if d < 0.0 then Split.Right
           else Split.Throwaway
         end
+      (* val (above, below) = *)
+      (* Split.parSplit allIdx (DS.force (DS.map flag allIdx)) *)
+      (* Split.parSplit (Seq.tabulate (fn i => i) (Seq.length pts))
+        (Seq.tabulate flag (Seq.length pts)) *)
+
+
+      val flags =
+        Seq.tabulate
+          (fn i =>
+             let
+               val d = dist lp rp i
+             in
+               if d > 0.0 then 0w0 : Word8.word
+               else if d < 0.0 then 0w1
+               else 0w2
+             end) (Seq.length pts)
+
       val (above, below) =
-        (* Split.parSplit allIdx (DS.force (DS.map flag allIdx)) *)
-        Split.parSplit (Seq.tabulate (fn i => i) (Seq.length pts))
-          (Seq.tabulate flag (Seq.length pts))
+        ForkJoin.par
+          ( fn _ =>
+              ArraySlice.full
+                (SeqBasis.filter 2000 (0, Seq.length pts) (fn i => i) (fn i =>
+                   Seq.nth flags i = 0w0))
+          , fn _ =>
+              ArraySlice.full
+                (SeqBasis.filter 2000 (0, Seq.length pts) (fn i => i) (fn i =>
+                   Seq.nth flags i = 0w1))
+          )
 
-      (* val tm = Util.tick tm "above/below filter" *)
 
-      val (above, below) = ForkJoin.par (fn _ => parHull above l r, fn _ =>
-        parHull below r l)
+      val _ = print
+        ("above "
+         ^
+         Real.fmt (StringCvt.FIX (SOME 1))
+           (100.0 * Real.fromInt (Seq.length above)
+            / Real.fromInt (Seq.length pts)) ^ "%\n")
+      val _ = print
+        ("below "
+         ^
+         Real.fmt (StringCvt.FIX (SOME 1))
+           (100.0 * Real.fromInt (Seq.length below)
+            / Real.fromInt (Seq.length pts)) ^ "%\n")
 
-      (* val tm = Util.tick tm "quickhull" *)
+      val tm = tick tm "above/below filter"
+
+      val (above, below) =
+        ForkJoin.par (fn _ => parHull_choose above l r, fn _ =>
+          parHull below r l)
+
+      val tm = tick tm "quickhull"
 
       val hullt = Tree.append
         (Tree.append (Tree.$ l, above), Tree.append (Tree.$ r, below))
 
       val result = Tree.toArraySeq hullt
 
-    (* val tm = Util.tick tm "flatten" *)
+      val tm = tick tm "flatten"
     in
       result
     end

--- a/bench/quickhull/sml/Quickhull.sml
+++ b/bench/quickhull/sml/Quickhull.sml
@@ -74,22 +74,12 @@ struct
             val rp = pt r
             fun d i =
               dist lp rp i
-            (* val idxs = DS.fromArraySeq idxs *)
 
             val (mid, _) =
               SeqBasis.reduce 5000 max (~1, Real.negInf) (0, Seq.length idxs)
                 (fn i => (Seq.nth idxs i, d (Seq.nth idxs i)))
-            (* val distances = DS.map (fn i => (i, d i)) idxs
-            val (mid, _) = DS.reduce max (~1, Real.negInf) distances *)
 
             val midp = pt mid
-
-            fun flag i =
-              if aboveLine lp midp i then Split.Left
-              else if aboveLine midp rp i then Split.Right
-              else Split.Throwaway
-            (* val (left, right) = Split.parSplit idxs (Seq.map flag idxs) *)
-            (* (DS.force (DS.map flag idxs)) *)
 
             fun flag i =
               if aboveLine lp midp i then 0w0
@@ -169,33 +159,7 @@ struct
           , prefer_gpu = fn _ => Tree.fromArraySeq (topDoGpu (l, r))
           }
 
-      (*
-      in
-        if Seq.length idxs < 2 then
-          Tree.fromArraySeq idxs
-        (* if DS.length idxs <= 2048 then
-           seqHull idxs l r *)
-        else if hybrid then
-          ForkJoin.choice
-            { prefer_cpu = doCpu
-            , prefer_gpu = fn () => Tree.fromArraySeq (doGpu (idxs, l, r))
-            }
-        else
-          doCpu ()
-      end
-      *)
-
       val tm = startTiming ()
-
-      (* val allIdx = DS.tabulate (fn i => i) (Seq.length pts) *)
-
-      (* This is faster than doing two reduces *)
-      (* val (l, r) = DS.reduce
-        (fn ((l1, r1), (l2, r2)) =>
-          (if x l1 < x l2 then l1 else l2,
-           if x r1 > x r2 then r1 else r2))
-        (0, 0)
-        (DS.map (fn i => (i, i)) allIdx) *)
 
       val (l, r) =
         if hybrid then
@@ -208,20 +172,6 @@ struct
 
       val lp = pt l
       val rp = pt r
-
-      (* fun flag i =
-        let
-          val d = dist lp rp i
-        in
-          if d > 0.0 then Split.Left
-          else if d < 0.0 then Split.Right
-          else Split.Throwaway
-        end *)
-      (* val (above, below) = *)
-      (* Split.parSplit allIdx (DS.force (DS.map flag allIdx)) *)
-      (* Split.parSplit (Seq.tabulate (fn i => i) (Seq.length pts))
-        (Seq.tabulate flag (Seq.length pts)) *)
-
 
       val (above, below, tm) =
         if hybrid then


### PR DESCRIPTION
A few changes:
  * top-level split is now hybridized, including (a) computing the initial splitter, and (b) filtering above/below the splitter
  * CPU-side code now uses a manually flattened point seq, to workaround MPL/MLton compiler heuristics not choosing to automatically flatten.

On my machine, for uniform random points in a circle:
  * single-core hybrid performance now matches GPU performance, and
  * 32-core hybrid performance outperforms GPU by ~40%.

However, there is still a performance issue: there is a performance dip when using only a few cores (e.g. 2-8 cores). The reason is that I only hybridized the top-level split. So, when using, say, 2 cores, the top-level split is fast but then we immediately get stuck with a slower semihull on the CPU side.

To fix this, we just need to hybridize the split within the semihull. This is not difficult; it just requires adding one or two more Futhark entrypoints.