### PR TITLE
Support multi gpu in benchmarks

### DIFF
--- a/bench/build-intervaltree/FutSort.sml
+++ b/bench/build-intervaltree/FutSort.sml
@@ -11,12 +11,12 @@ struct
   (* NOTE: need to pass the `vals` array here, see note in HybridSort where
    * FutSort.sort is called
    *)
-  fun init (vals: Int32.int Seq.t) =
+  fun init (vals: Int32.int Seq.t) (device: string)=
     let
       val (data, start, len) = ArraySlice.base vals
-      val f = _import "fut_init" public : i32 array * i64 * i64 -> fut_context;
+      val f = _import "fut_init" public : string * i32 array * i64 * i64 -> fut_context;
     in
-      f (data, start, len)
+      f (device, data, start, len)
     end
 
   fun cleanup x =

--- a/bench/build-intervaltree/glue.c
+++ b/bench/build-intervaltree/glue.c
@@ -13,12 +13,13 @@ struct fut_context
   struct futhark_i32_1d *vals;
 };
 
-void *fut_init(int32_t *vals, int64_t start, int64_t len)
+void *fut_init(unsigned char *device, int32_t *vals, int64_t start, int64_t len)
 {
   struct timer_t t;
   timer_begin(&t, "fut_init");
 
   struct futhark_context_config *cfg = futhark_context_config_new();
+  futhark_context_config_set_device(cfg, device);
   timer_report_tick(&t, "futhark_context_config_new");
 
   struct futhark_context *ctx = futhark_context_new(cfg);
@@ -68,7 +69,7 @@ struct sort_pack
   int32_t *input;
   int64_t start;
   int64_t len;
-  
+
   int32_t *output;
 };
 

--- a/bench/build-intervaltree/main.sml
+++ b/bench/build-intervaltree/main.sml
@@ -3,14 +3,14 @@ structure CLA = CommandLineArgs
 val n = CLA.parseInt "n" 5000000
 val impl = CLA.parseString "impl" "hybrid"
 val reportSize = CLA.parseFlag "report-size"
-val devices = ["#0", "#1"]
+val devices = String.fields (fn c => c = #",")
+  (CommandLineArgs.parseString "devices" "")
 
 val _ = print ("n " ^ Int.toString n ^ "\n")
 val _ = print ("impl " ^ impl ^ "\n")
 val _ = print
   ("report-size? " ^ (if reportSize then "true" else "false") ^ "\n")
-val _ = print
-  ("devices " ^ String.concatWith ", " devices ^ "\n")
+val _ = print ("devices " ^ String.concatWith ", " devices ^ "\n")
 
 
 fun cmpWith vals (i, j) =
@@ -63,7 +63,9 @@ fun query tree seed =
 val segs = Seq.tabulate (fn i => randSeg (2 * i)) n
 val segs_xs = Seq.map #1 segs
 
-val ctxSet = Seq.map (fn device => (device, FutSort.init segs_xs device)) (Seq.fromList devices)
+val ctxSet =
+  Seq.map (fn device => (device, FutSort.init segs_xs device))
+    (Seq.fromList devices)
 
 val _ =
   if not reportSize then

--- a/bench/kmeans/main.sml
+++ b/bench/kmeans/main.sml
@@ -62,7 +62,7 @@ val () = print ("Max iterations: " ^ Int.toString max_iterations ^ "\n")
 structure CtxSet = CtxSetFn (structure F = Futhark)
 val () = print "Initialising Futhark context... "
 val ctxSet = CtxSet.fromList devices
-val ctx = CtxSet.choose ctxSet "#1"
+val ctx = CtxSet.getOne ctxSet
 val () = print "Done!\n"
 
 structure FutharkPoints = GpuData(type t = Futhark.Real64Array2.array)

--- a/bench/kmeans/main.sml
+++ b/bench/kmeans/main.sml
@@ -17,6 +17,9 @@ val k = CLA.parseInt "k" 5
 
 val profile = CommandLineArgs.parseFlag "profile"
 
+val devices = String.fields (fn c => c = #",")
+  (CommandLineArgs.parseString "devices" "")
+
 val max_iterations = CLA.parseInt "max-iterations" 10
 
 val impl = CommandLineArgs.parseString "impl" "cpu"
@@ -58,7 +61,7 @@ val () = print ("Max iterations: " ^ Int.toString max_iterations ^ "\n")
 
 structure CtxSet = CtxSetFn (structure F = Futhark)
 val () = print "Initialising Futhark context... "
-val ctxSet = CtxSet.fromList ["#1", "#2"]
+val ctxSet = CtxSet.fromList devices
 val ctx = CtxSet.choose ctxSet "#1"
 val () = print "Done!\n"
 

--- a/bench/kmeans/sml/Kmeans.sml
+++ b/bench/kmeans/sml/Kmeans.sml
@@ -40,6 +40,8 @@ initialising the centroids to be specific points.)
 
 structure Kmeans:
 sig
+  type device_identifier
+
   val centroidsChunkCPU: Points.t -> int * int * Points.t -> Points.t
   val kmeansHybrid: (int * int * Points.t -> Points.t)
                     -> int
@@ -50,13 +52,15 @@ sig
   val kmeans': int -> int -> Points.t -> int * Points.t
   val kmeans'': int -> int -> Points.t -> int * Points.t
   val kmeansNewHybrid:
-    (Points.t -> {kernel: (int * int) -> real array Seq.t, after: unit -> unit})
+    (Points.t -> {kernel: device_identifier -> (int * int) -> real array Seq.t, after: unit -> unit})
     -> int
     -> int
     -> Points.t
     -> int * Points.t
 end =
 struct
+  type device_identifier = Device.device_identifier
+
   fun distance x y =
     let
       val d = Seq.length x

--- a/bench/mandelbrot/FutMandelbrot.sml
+++ b/bench/mandelbrot/FutMandelbrot.sml
@@ -2,7 +2,8 @@ structure FutMandelbrot =
 struct
 
   val profile = CommandLineArgs.parseFlag "profile"
-  val devices = String.fields (fn c => c = #",") (CommandLineArgs.parseString "devices" "")
+  val devices = String.fields (fn c => c = #",")
+    (CommandLineArgs.parseString "devices" "")
 
   structure CtxSet = CtxSetFn (structure F = FutharkMandelbrot)
 
@@ -21,14 +22,18 @@ struct
     end
 
   fun cleanup ctxSet =
-  let 
-  val (_, ctx) = Seq.first ctxSet (* FIXME *)
-  in
-    ( if profile then (writeFile "futhark.json" (FutharkMandelbrot.Context.report ctx))
-      else ()
+    ( if profile then
+        List.foldl
+          ( fn (ctx, idx) =>
+              (writeFile "futhark" ^ (Int.toString idx)
+               ^ ".json" (FutharkMandelbrot.Context.report ctx))
+          ; idx + 1
+          ) 0 (CtxSet.toCtxList ctxSet)
+
+      else
+        ()
     ; CtxSet.free ctxSet
     )
-    end
 
   type i64 = Int64.int
   type i32 = Int32.int

--- a/bench/mandelbrot/FutMandelbrot.sml
+++ b/bench/mandelbrot/FutMandelbrot.sml
@@ -2,13 +2,14 @@ structure FutMandelbrot =
 struct
 
   val profile = CommandLineArgs.parseFlag "profile"
+  val devices = String.fields (fn c => c = #",") (CommandLineArgs.parseString "devices" "")
 
   structure CtxSet = CtxSetFn (structure F = FutharkMandelbrot)
 
   fun init () =
     let
       val () = print "Initialising Futhark context... "
-      val ctxSet = CtxSet.fromList ["#0", "#1"]
+      val ctxSet = CtxSet.fromList devices
       val () = print "Done!\n"
     in
       ctxSet

--- a/bench/mandelbrot/main.sml
+++ b/bench/mandelbrot/main.sml
@@ -90,7 +90,7 @@ fun packByte y (xlo, xhi) =
 
 
 val ctxSet = FutMandelbrot.init ()
-val (_, ctx) = Seq.first ctxSet (* use the first gpu for gpu benchmarks *)
+val ctx = FutMandelbrot.CtxSet.getOne ctxSet
 
 
 fun hybridMandelbrot () : Word8.word Seq.t Seq.t =

--- a/bench/mandelbrot/main.sml
+++ b/bench/mandelbrot/main.sml
@@ -89,8 +89,6 @@ fun packByte y (xlo, xhi) =
 (* ======================================================================== *)
 
 
-structure CtxSet = CtxSetFn (structure F = FutharkMandelbrot)
-
 val ctxSet = FutMandelbrot.init ()
 val (_, ctx) = Seq.first ctxSet (* use the first gpu for gpu benchmarks *)
 
@@ -115,7 +113,7 @@ fun hybridMandelbrot () : Word8.word Seq.t Seq.t =
 
     fun do_gpu_rows device (ylo, yhi) =
       let
-        val outputArr = FutMandelbrot.mandelbrot (CtxSet.choose ctxSet device) ylo yhi 0 numBytesPerRow
+        val outputArr = FutMandelbrot.mandelbrot (FutMandelbrot.CtxSet.choose ctxSet device) ylo yhi 0 numBytesPerRow
         fun slice i =
           ArraySlice.slice (outputArr, i * numBytesPerRow, SOME numBytesPerRow)
       in

--- a/bench/mandelbrot/main.sml
+++ b/bench/mandelbrot/main.sml
@@ -89,7 +89,10 @@ fun packByte y (xlo, xhi) =
 (* ======================================================================== *)
 
 
-val ctx = FutMandelbrot.init ()
+structure CtxSet = CtxSetFn (structure F = FutharkMandelbrot)
+
+val ctxSet = FutMandelbrot.init ()
+val (_, ctx) = Seq.first ctxSet (* use the first gpu for gpu benchmarks *)
 
 
 fun hybridMandelbrot () : Word8.word Seq.t Seq.t =
@@ -110,9 +113,9 @@ fun hybridMandelbrot () : Word8.word Seq.t Seq.t =
              byte
            end)))
 
-    fun do_gpu_rows (ylo, yhi) =
+    fun do_gpu_rows device (ylo, yhi) =
       let
-        val outputArr = FutMandelbrot.mandelbrot ctx ylo yhi 0 numBytesPerRow
+        val outputArr = FutMandelbrot.mandelbrot (CtxSet.choose ctxSet device) ylo yhi 0 numBytesPerRow
         fun slice i =
           ArraySlice.slice (outputArr, i * numBytesPerRow, SOME numBytesPerRow)
       in
@@ -152,7 +155,7 @@ fun gpuMandelbrot () =
     fun ensureOnGpu () =
       ForkJoin.choice
         { prefer_cpu = ensureOnGpu
-        , prefer_gpu = fn () =>
+        , prefer_gpu = fn _ =>
             let
               val outputArr = FutMandelbrot.mandelbrot ctx 0 h 0 numBytesPerRow
               fun slice i =
@@ -186,7 +189,7 @@ val bench =
 
 val results = Benchmark.run "running mandelbrot" bench
 
-val _ = FutMandelbrot.cleanup ctx
+val _ = FutMandelbrot.cleanup ctxSet
 
 val outfile = CLA.parseString "output" ""
 

--- a/bench/mergesort/CtxMap.sml
+++ b/bench/mergesort/CtxMap.sml
@@ -22,6 +22,10 @@ struct
     Seq.map (fn (_, ctx) => FutharkSort.Context.free ctx) ctxMap
 
   fun choose (ctxMap: ctx_map) (device: device_identifier) =
-    #2 (Seq.first (Seq.filter (fn (name, _) => name = device) ctxMap))
-
+  let
+    val (device, ctx) = Seq.first (Seq.filter (fn (name, _) => name = device) ctxMap)
+    val _ = print ("chosen device: " ^ device ^ "\n")
+  in
+  ctx
+  end
 end

--- a/bench/mergesort/CtxMap.sml
+++ b/bench/mergesort/CtxMap.sml
@@ -1,0 +1,27 @@
+structure CtxMap:
+sig
+  type device_identifier = string
+  type ctx_map = (device_identifier * FutharkSort.ctx) Seq.t
+  val fromList: device_identifier list -> ctx_map
+  val choose: ctx_map -> device_identifier -> FutharkSort.ctx
+end =
+struct
+  type device_identifier = string
+  type ctx_map = (device_identifier * FutharkSort.ctx) Seq.t
+
+  fun fromList (devices: device_identifier list) =
+    Seq.map
+      (fn name =>
+         ( name
+         , FutharkSort.Context.new
+             (FutharkSort.Config.cache (SOME "futhark.cache")
+                (FutharkSort.Config.device (SOME name) FutharkSort.Config.default))
+         )) (Seq.fromList devices)
+
+  fun free (ctxMap: ctx_map) =
+    Seq.map (fn (_, ctx) => FutharkSort.Context.free ctx) ctxMap
+
+  fun choose (ctxMap: ctx_map) (device: device_identifier) =
+    #2 (Seq.first (Seq.filter (fn (name, _) => name = device) ctxMap))
+
+end

--- a/bench/mergesort/HybridMerge.sml
+++ b/bench/mergesort/HybridMerge.sml
@@ -1,5 +1,6 @@
 structure HybridMerge =
 struct
+  structure CtxSet = CtxSetFn (structure F = FutharkSort)
 
   fun slice_idxs s i j =
     ArraySlice.subslice (s, i, SOME (j - i))
@@ -54,7 +55,7 @@ struct
       ForkJoin.choice
         { prefer_cpu = fn _ => Merge.writeMerge Int32.compare (s1, s2) t
         , prefer_gpu = fn device =>
-            write_merge_gpu (CtxMap.choose ctxMap device) (s1, s2) t
+            write_merge_gpu (CtxSet.choose ctxMap device) (s1, s2) t
         }
     else
       let
@@ -85,7 +86,7 @@ struct
     else
       ForkJoin.choice
         { prefer_cpu = fn _ => write_merge ctxMap (s1, s2) t
-        , prefer_gpu = fn device => write_merge_gpu (CtxMap.choose ctxMap device) (s1, s2) t
+        , prefer_gpu = fn device => write_merge_gpu (CtxSet.choose ctxMap device) (s1, s2) t
         }
 
 

--- a/bench/mergesort/HybridSort.sml
+++ b/bench/mergesort/HybridSort.sml
@@ -1,5 +1,6 @@
 structure HybridSort =
 struct
+  structure CtxSet = CtxSetFn (structure F = FutharkSort)
 
   val gpu_sort_name = CommandLineArgs.parseString "gpu-sort" "radix"
   val futhark_sort =
@@ -65,7 +66,7 @@ struct
         if Seq.length xs <= sort_grain then
           ForkJoin.choice
             { prefer_cpu = fn _ => sort_cpu xs
-            , prefer_gpu = fn device => sort_gpu (CtxMap.choose ctxMap device) xs
+            , prefer_gpu = fn device => sort_gpu (CtxSet.choose ctxMap device) xs
             }
         else
           let
@@ -85,7 +86,7 @@ struct
           ForkJoin.choice
             { prefer_cpu = fn _ => loop xs
             , prefer_gpu = fn device =>
-                sort_gpu (CtxMap.choose ctxMap device) xs
+                sort_gpu (CtxSet.choose ctxMap device) xs
             }
 
     in

--- a/bench/mergesort/HybridSort.sml
+++ b/bench/mergesort/HybridSort.sml
@@ -58,7 +58,7 @@ struct
   fun split n =
     Real.ceil (sort_split * Real.fromInt n)
 
-  fun sort ctxMap input =
+  fun sort ctxSet input =
     let
       val n = Seq.length input
 
@@ -66,7 +66,7 @@ struct
         if Seq.length xs <= sort_grain then
           ForkJoin.choice
             { prefer_cpu = fn _ => sort_cpu xs
-            , prefer_gpu = fn device => sort_gpu (CtxSet.choose ctxMap device) xs
+            , prefer_gpu = fn device => sort_gpu (CtxSet.choose ctxSet device) xs
             }
         else
           let
@@ -76,7 +76,7 @@ struct
             val (left', right') =
               ForkJoin.par (fn _ => loop_choose left, fn _ => loop right)
           in
-            HybridMerge.merge ctxMap (left', right')
+            HybridMerge.merge ctxSet (left', right')
           end
 
       and loop_choose xs =
@@ -86,7 +86,7 @@ struct
           ForkJoin.choice
             { prefer_cpu = fn _ => loop xs
             , prefer_gpu = fn device =>
-                sort_gpu (CtxSet.choose ctxMap device) xs
+                sort_gpu (CtxSet.choose ctxSet device) xs
             }
 
     in

--- a/bench/mergesort/Makefile
+++ b/bench/mergesort/Makefile
@@ -10,7 +10,7 @@ main.mlton.bin: phony $(FDIR)/sort.sml
 
 $(FDIR)/sort.sml: $(FDIR)/sort.fut $(FDIR)/lib
 	futhark $(FUTHARK_BACKEND) --library $(FDIR)/sort.fut
-	smlfut -o $(FDIR) --poly-arrays  --structure=FutharkSort --signature=FUTHARK_SORT $(FDIR)/sort.json
+	smlfut -o $(FDIR) --poly-arrays  --structure=FutharkSort --signature=FUTHARK_SORT$(FDIR)/sort.json
 
 $(FDIR)/lib:
 	(cd $(FDIR); futhark pkg sync)

--- a/bench/mergesort/main.mlb
+++ b/bench/mergesort/main.mlb
@@ -1,6 +1,7 @@
 ../../dep/dep.mlb
 futhark/sort.sig
 futhark/sort.sml
+CtxMap.sml
 DualBinarySearch.sml
 HybridMerge.sml
 HybridSort.sml

--- a/bench/mergesort/main.mlb
+++ b/bench/mergesort/main.mlb
@@ -1,7 +1,6 @@
 ../../dep/dep.mlb
 futhark/sort.sig
 futhark/sort.sml
-CtxMap.sml
 DualBinarySearch.sml
 HybridMerge.sml
 HybridSort.sml

--- a/bench/mergesort/main.sml
+++ b/bench/mergesort/main.sml
@@ -9,7 +9,7 @@ val _ = print ("n " ^ Int.toString n ^ "\n")
 val _ = print ("impl " ^ impl ^ "\n")
 val _ = print ("devices " ^ String.concatWith "," devices ^ "\n")
 
-val () = print "Initialising Futhark context map... "
+val () = print "Initialising Futhark context... "
 
 val ctxSet = CtxSet.fromList devices
 val (_, ctx) = Seq.first ctxSet (* use the first gpu for gpu benchmarks *)

--- a/bench/mergesort/main.sml
+++ b/bench/mergesort/main.sml
@@ -12,7 +12,7 @@ val _ = print ("devices " ^ String.concatWith "," devices ^ "\n")
 val () = print "Initialising Futhark context... "
 
 val ctxSet = CtxSet.fromList devices
-val (_, ctx) = Seq.first ctxSet (* use the first gpu for gpu benchmarks *)
+val ctx = CtxSet.getOne ctxSet
 
 val () = print "Done!\n"
 

--- a/bench/mergesort/main.sml
+++ b/bench/mergesort/main.sml
@@ -4,12 +4,14 @@ structure CtxSet = CtxSetFn (structure F = FutharkSort)
 
 val n = CLA.parseInt "n" (100 * 1000 * 1000)
 val impl = CLA.parseString "impl" "hybrid"
+val devices = String.fields (fn c => c = #",") (CLA.parseString "devices" "")
 val _ = print ("n " ^ Int.toString n ^ "\n")
 val _ = print ("impl " ^ impl ^ "\n")
+val _ = print ("devices " ^ String.concatWith "," devices ^ "\n")
 
 val () = print "Initialising Futhark context map... "
 
-val ctxSet = CtxSet.fromList ["#0", "#1"] (* TODO: Read it from configuration *)
+val ctxSet = CtxSet.fromList devices
 val (_, ctx) = Seq.first ctxSet (* use the first gpu for gpu benchmarks *)
 
 val () = print "Done!\n"

--- a/bench/mergesort/main.sml
+++ b/bench/mergesort/main.sml
@@ -1,5 +1,7 @@
 structure CLA = CommandLineArgs
 
+structure CtxSet = CtxSetFn (structure F = FutharkSort)
+
 val n = CLA.parseInt "n" (100 * 1000 * 1000)
 val impl = CLA.parseString "impl" "hybrid"
 val _ = print ("n " ^ Int.toString n ^ "\n")
@@ -7,8 +9,8 @@ val _ = print ("impl " ^ impl ^ "\n")
 
 val () = print "Initialising Futhark context map... "
 
-val ctxMap = CtxMap.fromList ["#0", "#1"] (* TODO: Read it from configuration *)
-val (_, ctx) = Seq.first ctxMap (* use the first gpu for gpu benchmarks *)
+val ctxSet = CtxSet.fromList ["#0", "#1"] (* TODO: Read it from configuration *)
+val (_, ctx) = Seq.first ctxSet (* use the first gpu for gpu benchmarks *)
 
 val () = print "Done!\n"
 
@@ -20,7 +22,7 @@ val input = Seq.tabulate elem n
 
 val bench =
   case impl of
-    "hybrid" => (fn () => HybridSort.sort ctxMap input)
+    "hybrid" => (fn () => HybridSort.sort ctxSet input)
   | "cpu" => (fn () => HybridSort.sort_cpu input)
   | "gpu" => (fn () => HybridSort.sort_gpu ctx input)
   | _ => Util.die ("unknown impl: " ^ impl)
@@ -32,5 +34,4 @@ val _ = print
 val _ = print
   ("result " ^ Util.summarizeArraySlice 8 Int32.toString result ^ "\n")
 
-(* TODO: Use foreach *)
-val _ = Seq.map (fn (name, ctx) => FutharkSort.Context.free ctx) ctxMap
+val _ = CtxSet.free ctxSet

--- a/bench/mergesort/main.sml
+++ b/bench/mergesort/main.sml
@@ -5,9 +5,11 @@ val impl = CLA.parseString "impl" "hybrid"
 val _ = print ("n " ^ Int.toString n ^ "\n")
 val _ = print ("impl " ^ impl ^ "\n")
 
-val () = print "Initialising Futhark context... "
-val ctx = FutharkSort.Context.new
-  (FutharkSort.Config.cache (SOME "futhark.cache") FutharkSort.Config.default)
+val () = print "Initialising Futhark context map... "
+
+val ctxMap = CtxMap.fromList ["#0", "#1"] (* TODO: Read it from configuration *)
+val (_, ctx) = Seq.first ctxMap (* use the first gpu for gpu benchmarks *)
+
 val () = print "Done!\n"
 
 val _ = print ("generating " ^ Int.toString n ^ " random integers\n")
@@ -18,7 +20,7 @@ val input = Seq.tabulate elem n
 
 val bench =
   case impl of
-    "hybrid" => (fn () => HybridSort.sort ctx input)
+    "hybrid" => (fn () => HybridSort.sort ctxMap input)
   | "cpu" => (fn () => HybridSort.sort_cpu input)
   | "gpu" => (fn () => HybridSort.sort_gpu ctx input)
   | _ => Util.die ("unknown impl: " ^ impl)
@@ -30,4 +32,5 @@ val _ = print
 val _ = print
   ("result " ^ Util.summarizeArraySlice 8 Int32.toString result ^ "\n")
 
-val _ = FutharkSort.Context.free ctx
+(* TODO: Use foreach *)
+val _ = Seq.map (fn (name, ctx) => FutharkSort.Context.free ctx) ctxMap

--- a/bench/primes/main.sml
+++ b/bench/primes/main.sml
@@ -1,9 +1,9 @@
 structure CLA = CommandLineArgs
 
+
 val () = print "Initialising Futhark context... "
-val ctx = FutharkPrimes.Context.new
-  (FutharkPrimes.Config.cache (SOME "futhark.cache")
-     FutharkPrimes.Config.default)
+val ctxSet = SegmentedPrimes.CtxSet.fromList ["#0", "#1"]
+val (_, ctx) = Seq.first ctxSet
 val () = print "Done!\n"
 
 val n = CommandLineArgs.parseInt "n" (100 * 1000 * 1000)
@@ -18,7 +18,7 @@ val doit =
   case impl of
     "cpu" => SegmentedPrimes.primes_cpu
   | "gpu" => singleton o SegmentedPrimes.primes_gpu ctx
-  | "hybrid" => SegmentedPrimes.primes_hybrid ctx
+  | "hybrid" => SegmentedPrimes.primes_hybrid ctxSet
   | _ => Util.die ("unknown -impl " ^ impl)
 
 val result = Benchmark.run ("primes " ^ impl) (fn () => doit n)
@@ -27,4 +27,4 @@ val numPrimes = SeqBasis.reduce 1000 (op+) 0 (0, Array.length result) (fn i =>
   Array.length (Array.sub (result, i)))
 val _ = print ("num primes " ^ Int.toString numPrimes ^ "\n")
 
-val _ = FutharkPrimes.Context.free ctx
+val _ = SegmentedPrimes.CtxSet.free ctxSet

--- a/bench/primes/main.sml
+++ b/bench/primes/main.sml
@@ -1,8 +1,10 @@
 structure CLA = CommandLineArgs
 
+val devices = String.fields (fn c => c = #",")
+  (CommandLineArgs.parseString "devices" "")
 
 val () = print "Initialising Futhark context... "
-val ctxSet = SegmentedPrimes.CtxSet.fromList ["#0", "#1"]
+val ctxSet = SegmentedPrimes.CtxSet.fromList devices
 val (_, ctx) = Seq.first ctxSet
 val () = print "Done!\n"
 

--- a/bench/primes/main.sml
+++ b/bench/primes/main.sml
@@ -5,7 +5,7 @@ val devices = String.fields (fn c => c = #",")
 
 val () = print "Initialising Futhark context... "
 val ctxSet = SegmentedPrimes.CtxSet.fromList devices
-val (_, ctx) = Seq.first ctxSet
+val ctx = CtxSet.getOne ctxSet
 val () = print "Done!\n"
 
 val n = CommandLineArgs.parseInt "n" (100 * 1000 * 1000)

--- a/bench/quickhull/main.sml
+++ b/bench/quickhull/main.sml
@@ -30,7 +30,7 @@ structure CtxSet = CtxSetFn (structure F = Futhark)
 
 val () = print "Initialising Futhark context... "
 val ctxSet = CtxSet.fromList ["#1", "#2"]
-val ctx = CtxSet.choose ctxSet "#1"
+val ctx = CtxSet.getOne ctxSet
 val () = print "Done!\n"
 
 fun futharkPoints (points: FlatPointSeq.t) ctx =

--- a/bench/quickhull/main.sml
+++ b/bench/quickhull/main.sml
@@ -54,7 +54,7 @@ val bench =
 
 val result = Benchmark.run ("quickhull " ^ impl) bench
 
-val () = Futhark.Real64Array2.free points_fut
-val () = Futhark.Context.free ctx
+val () = FutharkPoints.free points_fut_set Futhark.Real64Array2.free 
+val () = CtxSet.free ctxSet
 val () = print
   ("Points in convex hull: " ^ Int.toString (Seq.length result) ^ "\n")

--- a/bench/quickhull/main.sml
+++ b/bench/quickhull/main.sml
@@ -5,6 +5,9 @@ val file = CLA.parseString "points" ""
 
 val impl = CommandLineArgs.parseString "impl" "cpu"
 
+val devices = String.fields (fn c => c = #",")
+  (CommandLineArgs.parseString "devices" "")
+
 val points =
   if file = "" then
     raise Fail "Need -points FILE"
@@ -29,7 +32,7 @@ fun randomPoints n =
 structure CtxSet = CtxSetFn (structure F = Futhark)
 
 val () = print "Initialising Futhark context... "
-val ctxSet = CtxSet.fromList ["#1", "#2"]
+val ctxSet = CtxSet.fromList devices
 val ctx = CtxSet.getOne ctxSet
 val () = print "Done!\n"
 

--- a/bench/raytracer/FutRay.sml
+++ b/bench/raytracer/FutRay.sml
@@ -2,13 +2,14 @@ structure FutRay =
 struct
 
   val profile = CommandLineArgs.parseFlag "profile"
+  val devices = String.fields (fn c => c = #",") (CLA.parseString "devices" "")
 
   structure CtxSet = CtxSetFn (structure F = Futhark)
 
   fun init () =
     let
       val () = print "Initialising Futhark context... "
-      val ctxSet = CtxSet.fromList ["#0", "#1"]
+      val ctxSet = CtxSet.fromList devices
       val () = print "Done!\n"
     in
       ctxSet

--- a/bench/raytracer/FutRay.sml
+++ b/bench/raytracer/FutRay.sml
@@ -2,7 +2,8 @@ structure FutRay =
 struct
 
   val profile = CommandLineArgs.parseFlag "profile"
-  val devices = String.fields (fn c => c = #",") (CLA.parseString "devices" "")
+  val devices = String.fields (fn c => c = #",")
+    (CommandLineArgs.parseString "devices" "")
 
   structure CtxSet = CtxSetFn (structure F = Futhark)
 
@@ -23,12 +24,21 @@ struct
 
   fun cleanup ctxSet =
     ( if profile then
-        List.foldl
-          ( fn (ctx, idx) =>
-              (writeFile "futhark" ^ (Int.toString idx)
-               ^ ".json" (FutharkMandelbrot.Context.report ctx))
-          ; idx + 1
-          ) 0 (CtxSet.toCtxList ctxSet)
+        let
+          val _ =
+            List.foldl
+              (fn (ctx, idx) =>
+                 let
+                   val _ =
+                     (writeFile ("futhark" ^ (Int.toString idx) ^ ".json")
+                        (Futhark.Context.report ctx))
+                 in
+                   idx + 1
+                 end) 0 (CtxSet.toCtxList ctxSet)
+        in
+          ()
+        end
+
 
       else
         ()

--- a/bench/raytracer/FutRay.sml
+++ b/bench/raytracer/FutRay.sml
@@ -22,14 +22,18 @@ struct
     end
 
   fun cleanup ctxSet =
-    let
-      val (_, ctx) = Seq.first ctxSet (* FIXME *)
-    in
-      ( if profile then (writeFile "futhark.json" (Futhark.Context.report ctx))
-        else ()
-      ; CtxSet.free ctxSet
-      )
-    end
+    ( if profile then
+        List.foldl
+          ( fn (ctx, idx) =>
+              (writeFile "futhark" ^ (Int.toString idx)
+               ^ ".json" (FutharkMandelbrot.Context.report ctx))
+          ; idx + 1
+          ) 0 (CtxSet.toCtxList ctxSet)
+
+      else
+        ()
+    ; CtxSet.free ctxSet
+    )
 
   type i64 = Int64.int
   type i32 = Int32.int

--- a/bench/raytracer/Ray.sml
+++ b/bench/raytracer/Ray.sml
@@ -375,7 +375,7 @@ struct
   val renderHybridGrain = BenchParams.Raytracer.gpu_grain
 
 
-  fun render_hybrid ctxSet fut_prepared_scene objs width height cam : image =
+  fun render_hybrid ctxSet fut_prepared_scene_set objs width height cam : image =
     let
       val pixels: Int32.int array = ForkJoin.alloc (height * width)
 
@@ -389,8 +389,9 @@ struct
         end
 
       fun gpuTask device (lo, hi) =
-        FutRay.render (CtxSet.choose ctxSet device) fut_prepared_scene (ArraySlice.slice
-          (pixels, lo, SOME (hi - lo)))
+        FutRay.render (CtxSet.choose ctxSet device)
+          (FutRay.PreparedSceneSet.choose fut_prepared_scene_set device)
+          (ArraySlice.slice (pixels, lo, SOME (hi - lo)))
 
     in
       HybridBasis.parfor_hybrid renderHybridGpuSplit renderHybridGrain

--- a/bench/raytracer/main.sml
+++ b/bench/raytracer/main.sml
@@ -51,14 +51,13 @@ val bench =
            val ((objs, cam), tm1) = Util.getTime (fn _ =>
              Ray.from_scene width height scene)
            val _ = print ("Scene BVH construction in " ^ Time.fmt 4 tm1 ^ "s\n")
-           val (prepared_scene, tm2) = Util.getTime (fn _ =>
-             (* use the first gpu device *)
-             FutRay.prepare_rgbbox_scene (ctx, height, width))
-           val _ = print ("Futhark prep scene in " ^ Time.fmt 4 tm2 ^ "s\n")
+           val (prepared_scene_set, tm2) = Util.getTime (fn _ =>
+             FutRay.PreparedSceneSet.prepareFromCtxSet ctxSet (height, width))
+           val _ = print ("Futhark prep scenes in " ^ Time.fmt 4 tm2 ^ "s\n")
            val result =
-             Ray.render_hybrid ctxSet prepared_scene objs width height cam
+             Ray.render_hybrid ctxSet prepared_scene_set objs width height cam
          in
-           FutRay.prepare_rgbbox_scene_free prepared_scene;
+           FutRay.PreparedSceneSet.freeScene prepared_scene_set;
            result
          end)
 

--- a/bench/raytracer/main.sml
+++ b/bench/raytracer/main.sml
@@ -12,7 +12,8 @@ val scene =
   | "irreg" => raise Fail ("irreg scene not implemented yet")
   | s => raise Fail ("No such scene: " ^ s)
 
-val ctx = FutRay.init ()
+val ctxSet = FutRay.init ()
+val (_, ctx) = Seq.first ctxSet (* use the first gpu for gpu benchmarks *)
 
 val _ = print ("h " ^ Int.toString height ^ "\n")
 val _ = print ("w " ^ Int.toString width ^ "\n")
@@ -51,10 +52,11 @@ val bench =
              Ray.from_scene width height scene)
            val _ = print ("Scene BVH construction in " ^ Time.fmt 4 tm1 ^ "s\n")
            val (prepared_scene, tm2) = Util.getTime (fn _ =>
+             (* use the first gpu device *)
              FutRay.prepare_rgbbox_scene (ctx, height, width))
            val _ = print ("Futhark prep scene in " ^ Time.fmt 4 tm2 ^ "s\n")
            val result =
-             Ray.render_hybrid ctx prepared_scene objs width height cam
+             Ray.render_hybrid ctxSet prepared_scene objs width height cam
          in
            FutRay.prepare_rgbbox_scene_free prepared_scene;
            result
@@ -64,7 +66,7 @@ val bench =
 
 val result = Benchmark.run ("rendering (" ^ impl ^ ")") bench
 
-val _ = FutRay.cleanup ctx
+val _ = FutRay.cleanup ctxSet
 
 val writeImage = if dop6 then Ray.image2ppm6 else Ray.image2ppm
 

--- a/bench/raytracer/main.sml
+++ b/bench/raytracer/main.sml
@@ -13,7 +13,7 @@ val scene =
   | s => raise Fail ("No such scene: " ^ s)
 
 val ctxSet = FutRay.init ()
-val (_, ctx) = Seq.first ctxSet (* use the first gpu for gpu benchmarks *)
+val ctx = FutRay.CtxSet.getOne ctxSet
 
 val _ = print ("h " ^ Int.toString height ^ "\n")
 val _ = print ("w " ^ Int.toString width ^ "\n")

--- a/dep/CtxSet.sml
+++ b/dep/CtxSet.sml
@@ -1,33 +1,63 @@
 (* maintain a Futhark context for each gpu device *)
 
-structure CtxSet:
-sig
-  type device_identifier = string
-  type ctx_set = (device_identifier * FutharkSort.ctx) Seq.t
-  val fromList: device_identifier list -> ctx_set
-  val choose: ctx_set -> device_identifier -> FutharkSort.ctx
-end =
+functor CtxSetFn
+  (structure F:
+   sig
+     type ctx
+     exception Error of string
+     type cfg =
+       { logging: bool
+       , debugging: bool
+       , profiling: bool
+       , cache: string option
+       , tuning: (string * int) list
+       , device: string option
+       }
+
+     structure Config:
+     sig
+       val default: cfg
+       val logging: bool -> cfg -> cfg
+       val debugging: bool -> cfg -> cfg
+       val profiling: bool -> cfg -> cfg
+       val cache: string option -> cfg -> cfg
+       val tuning: (string * int) list -> cfg -> cfg
+       val device: string option -> cfg -> cfg
+     end
+
+     structure Context:
+     sig
+       val new: cfg -> ctx
+       val free: ctx -> unit
+     end
+   end) =
 struct
-  type device_identifier = string
-  type ctx_set = (device_identifier * FutharkSort.ctx) Seq.t
+  open Device
+
+  val profile = CommandLineArgs.parseFlag "profile"
+
+  type ctx_set = (device_identifier * F.ctx) Seq.t
 
   fun fromList (devices: device_identifier list) =
-    Seq.map
-      (fn name =>
-         ( name
-         , FutharkSort.Context.new
-             (FutharkSort.Config.cache (SOME "futhark.cache")
-                (FutharkSort.Config.device (SOME name) FutharkSort.Config.default))
-         )) (Seq.fromList devices)
+    Seq.map (fn name =>
+      let
+        val cfg =
+          (F.Config.cache (SOME "futhark.cache") o F.Config.device (SOME name)
+           o F.Config.profiling profile) F.Config.default
+        val ctx = F.Context.new cfg
+      in
+        (name, ctx)
+      end) (Seq.fromList devices)
 
   fun free (ctxMap: ctx_set) =
-    Seq.map (fn (_, ctx) => FutharkSort.Context.free ctx) ctxMap
+    Seq.map (fn (_, ctx) => F.Context.free ctx) ctxMap
 
   fun choose (ctxMap: ctx_set) (device: device_identifier) =
-  let
-    val (device, ctx) = Seq.first (Seq.filter (fn (name, _) => name = device) ctxMap)
-    val _ = print ("chosen device: " ^ device ^ "\n")
-  in
-  ctx
-  end
+    let
+      val (device, ctx) = Seq.first
+        (Seq.filter (fn (name, _) => name = device) ctxMap)
+      val _ = print ("chosen device: " ^ device ^ "\n")
+    in
+      ctx
+    end
 end

--- a/dep/CtxSet.sml
+++ b/dep/CtxSet.sml
@@ -1,13 +1,15 @@
-structure CtxMap:
+(* maintain a Futhark context for each gpu device *)
+
+structure CtxSet:
 sig
   type device_identifier = string
-  type ctx_map = (device_identifier * FutharkSort.ctx) Seq.t
-  val fromList: device_identifier list -> ctx_map
-  val choose: ctx_map -> device_identifier -> FutharkSort.ctx
+  type ctx_set = (device_identifier * FutharkSort.ctx) Seq.t
+  val fromList: device_identifier list -> ctx_set
+  val choose: ctx_set -> device_identifier -> FutharkSort.ctx
 end =
 struct
   type device_identifier = string
-  type ctx_map = (device_identifier * FutharkSort.ctx) Seq.t
+  type ctx_set = (device_identifier * FutharkSort.ctx) Seq.t
 
   fun fromList (devices: device_identifier list) =
     Seq.map
@@ -18,10 +20,10 @@ struct
                 (FutharkSort.Config.device (SOME name) FutharkSort.Config.default))
          )) (Seq.fromList devices)
 
-  fun free (ctxMap: ctx_map) =
+  fun free (ctxMap: ctx_set) =
     Seq.map (fn (_, ctx) => FutharkSort.Context.free ctx) ctxMap
 
-  fun choose (ctxMap: ctx_map) (device: device_identifier) =
+  fun choose (ctxMap: ctx_set) (device: device_identifier) =
   let
     val (device, ctx) = Seq.first (Seq.filter (fn (name, _) => name = device) ctxMap)
     val _ = print ("chosen device: " ^ device ^ "\n")

--- a/dep/CtxSet.sml
+++ b/dep/CtxSet.sml
@@ -65,4 +65,7 @@ struct
     in
       ctx
     end
+
+  fun toCtxList (ctxSet: ctx_set) =
+  Seq.toList (Seq.map (fn (_, ctx) => ctx) ctxSet)
 end

--- a/dep/CtxSet.sml
+++ b/dep/CtxSet.sml
@@ -67,5 +67,5 @@ struct
     end
 
   fun toCtxList (ctxSet: ctx_set) =
-  Seq.toList (Seq.map (fn (_, ctx) => ctx) ctxSet)
+    Seq.toList (Seq.map (fn (_, ctx) => ctx) ctxSet)
 end

--- a/dep/CtxSet.sml
+++ b/dep/CtxSet.sml
@@ -68,4 +68,16 @@ struct
 
   fun toCtxList (ctxSet: ctx_set) =
     Seq.toList (Seq.map (fn (_, ctx) => ctx) ctxSet)
+
+
+  (* 
+  Get one futhark context for single gpu benchmarks.
+  It selects the first one, which is arbitrarily chosen.
+  *)
+  fun getOne (ctxSet: ctx_set) =
+    let
+      val (_, ctx) = Seq.first ctxSet
+    in
+      ctx
+    end
 end

--- a/dep/CtxSet.sml
+++ b/dep/CtxSet.sml
@@ -39,18 +39,23 @@ struct
   type ctx_set = (device_identifier * F.ctx) Seq.t
 
   fun fromList (devices: device_identifier list) =
-    Seq.map (fn device =>
-      let
-        val cfg =
-          (F.Config.cache (SOME "futhark.cache") o F.Config.device (SOME device)
-           o F.Config.profiling profile) F.Config.default
-        val ctx = F.Context.new cfg
-      in
-        (device, ctx)
-      end) (Seq.fromList devices)
+    Seq.map
+      (fn device =>
+         let
+           val cfg =
+             (F.Config.cache (SOME "futhark.cache")
+              o F.Config.device (SOME device) o F.Config.profiling profile)
+               F.Config.default
+           val ctx = F.Context.new cfg
+         in
+           (device, ctx)
+         end) (Seq.fromList devices)
 
   fun free (ctxSet: ctx_set) =
-    Seq.map (fn (_, ctx) => F.Context.free ctx) ctxSet
+    let val _ = Seq.map (fn (_, ctx) => F.Context.free ctx) ctxSet
+    in ()
+    end
+
 
   fun choose (ctxSet: ctx_set) (device: device_identifier) =
     let

--- a/dep/CtxSet.sml
+++ b/dep/CtxSet.sml
@@ -39,23 +39,23 @@ struct
   type ctx_set = (device_identifier * F.ctx) Seq.t
 
   fun fromList (devices: device_identifier list) =
-    Seq.map (fn name =>
+    Seq.map (fn device =>
       let
         val cfg =
-          (F.Config.cache (SOME "futhark.cache") o F.Config.device (SOME name)
+          (F.Config.cache (SOME "futhark.cache") o F.Config.device (SOME device)
            o F.Config.profiling profile) F.Config.default
         val ctx = F.Context.new cfg
       in
-        (name, ctx)
+        (device, ctx)
       end) (Seq.fromList devices)
 
-  fun free (ctxMap: ctx_set) =
-    Seq.map (fn (_, ctx) => F.Context.free ctx) ctxMap
+  fun free (ctxSet: ctx_set) =
+    Seq.map (fn (_, ctx) => F.Context.free ctx) ctxSet
 
-  fun choose (ctxMap: ctx_set) (device: device_identifier) =
+  fun choose (ctxSet: ctx_set) (device: device_identifier) =
     let
       val (device, ctx) = Seq.first
-        (Seq.filter (fn (name, _) => name = device) ctxMap)
+        (Seq.filter (fn (d, _) => d = device) ctxSet)
       val _ = print ("chosen device: " ^ device ^ "\n")
     in
       ctx

--- a/dep/Device.sml
+++ b/dep/Device.sml
@@ -1,0 +1,4 @@
+structure Device =
+struct
+  type device_identifier = string
+end

--- a/dep/GpuData.sml
+++ b/dep/GpuData.sml
@@ -1,0 +1,17 @@
+(* data initially copied to GPU  a Futhark context for each gpu device *)
+
+functor GpuData (type t) =
+struct
+  open Device
+
+  type gpu_data = (device_identifier * t) Seq.t
+
+  fun initialize ctxSet f =
+    Seq.map (fn (device, ctx) => (device, f ctx)) ctxSet
+
+  fun free data f =
+    Seq.map (fn (_, d) => f d) data
+
+  fun choose data device =
+    #2 (Seq.first (Seq.filter (fn (d, _) => d = device) data))
+end

--- a/dep/GpuData.sml
+++ b/dep/GpuData.sml
@@ -10,7 +10,9 @@ struct
     Seq.map (fn (device, ctx) => (device, f ctx)) ctxSet
 
   fun free data f =
-    Seq.map (fn (_, d) => f d) data
+    let val _ = Seq.map (fn (_, d) => f d) data
+    in ()
+    end
 
   fun choose data device =
     #2 (Seq.first (Seq.filter (fn (d, _) => d = device) data))

--- a/dep/HybridBasis.sml
+++ b/dep/HybridBasis.sml
@@ -42,7 +42,7 @@ struct
 
 
   fun reduce_hybrid split grain combine z (lo, hi)
-    (f: int -> (int * int), g: device_identifier -> (int * int) -> (int * int)) =
+    (f: int -> 'a, g: device_identifier -> (int * int) -> 'a) =
     let
       fun base lo hi =
         SeqBasis.reduce grain combine z (lo, hi) f

--- a/dep/dep.mlb
+++ b/dep/dep.mlb
@@ -5,3 +5,4 @@ HybridBasis.sml
 BenchParams.sml
 CtxSet.sml
 Device.sml
+GpuData.sml

--- a/dep/dep.mlb
+++ b/dep/dep.mlb
@@ -4,3 +4,4 @@ TreeSeq.sml
 HybridBasis.sml
 BenchParams.sml
 CtxSet.sml
+Device.sml

--- a/dep/dep.mlb
+++ b/dep/dep.mlb
@@ -1,8 +1,8 @@
 lib/github.com/mpllang/mpllib/sources.mpl.mlb
 spinlock.mlb
 TreeSeq.sml
-HybridBasis.sml
-BenchParams.sml
-CtxSet.sml
 Device.sml
 GpuData.sml
+CtxSet.sml
+HybridBasis.sml
+BenchParams.sml

--- a/dep/dep.mlb
+++ b/dep/dep.mlb
@@ -3,3 +3,4 @@ spinlock.mlb
 TreeSeq.sml
 HybridBasis.sml
 BenchParams.sml
+CtxSet.sml


### PR DESCRIPTION
Note that this depends on https://github.com/MPLLang/mpl/tree/hybrid-sched-multi-gpu

# Benchmarks
- [x] mergesort
- [x] raytracer
- [x] mandelbrot
- [x] quickhull
- [x] primes
- [x] kmeans
- [x] intervaltree
- [ ] bfs
- [ ] dmm
- [ ] sparse_mxv 

