### PR TITLE
Multi Stream

### DIFF
--- a/bench/bfs/main.sml
+++ b/bench/bfs/main.sml
@@ -92,7 +92,8 @@ val do_bfs =
     | "gpu" =>
         (fn () =>
            let
-             val (dev, ctx) = Seq.first ctxSet
+             val dev = 0
+             val ctx = CtxSet.choose ctxSet dev
              val (graph_fut, _) = GpuData.choose graphs_fut dev
            in
              BFS.bfs_gpu ctx {diropt = diropt}

--- a/bench/bfs/sml/NondetBFS.sml
+++ b/bench/bfs/sml/NondetBFS.sml
@@ -486,7 +486,7 @@ struct
                 else
                   ForkJoin.choice
                     { prefer_cpu = fn _ => (loop i j; NONE)
-                    , prefer_gpu = fn (device: string) =>
+                    , prefer_gpu = fn (device: int) =>
                         let
                           val t0 = Time.now ()
                           val ctx = CtxSet.choose ctxSet device

--- a/bench/build-intervaltree/HybridSort.sml
+++ b/bench/build-intervaltree/HybridSort.sml
@@ -28,9 +28,8 @@ struct
 
   fun chooseCtx ctxSet device =
     let
-      val (device, ctx) = Seq.first
-        (Seq.filter (fn (d, _) => d = device) ctxSet)
-      val _ = print ("chosen device: " ^ device ^ "\n")
+      val (gpu, ctx) = Seq.nth ctxSet device
+      val _ = print ("chosen device: " ^ Int.toString device ^ ":" ^ gpu ^ "\n")
     in
       ctx
     end

--- a/bench/kmeans/main.sml
+++ b/bench/kmeans/main.sml
@@ -62,7 +62,8 @@ val () = print ("Max iterations: " ^ Int.toString max_iterations ^ "\n")
 structure CtxSet = CtxSetFn (structure F = Futhark)
 val () = print "Initialising Futhark context... "
 val ctxSet = CtxSet.fromList devices
-val (default_device, default_ctx) = Seq.first ctxSet
+val default_device = 0
+val default_ctx = CtxSet.choose ctxSet default_device
 val () = print "Done!\n"
 
 (* structure FutharkPoints = GpuData(type t = ) *)

--- a/bench/quickhull/main.sml
+++ b/bench/quickhull/main.sml
@@ -33,7 +33,8 @@ structure CtxSet = CtxSetFn (structure F = Futhark)
 
 val () = print "Initialising Futhark context... "
 val ctxSet = CtxSet.fromList devices
-val (default_device, default_ctx) = Seq.first ctxSet
+val default_device = 0
+val default_ctx = CtxSet.choose ctxSet default_device
 val () = print "Done!\n"
 
 structure Quickhull = Quickhull(CtxSet)

--- a/bench/raytracer/main.sml
+++ b/bench/raytracer/main.sml
@@ -13,7 +13,8 @@ val scene =
   | s => raise Fail ("No such scene: " ^ s)
 
 val ctxSet = FutRay.init ()
-val (default_device, default_ctx) = Seq.first ctxSet
+val default_device = 0
+val default_ctx = FutRay.CtxSet.choose ctxSet default_device
 
 val _ = print ("h " ^ Int.toString height ^ "\n")
 val _ = print ("w " ^ Int.toString width ^ "\n")

--- a/bench/sparse-mxv/main.sml
+++ b/bench/sparse-mxv/main.sml
@@ -36,7 +36,8 @@ val vec = Seq.tabulate (fn _ => M.R.fromInt 1) (M.I.toInt num_rows)
 val () = print "Initialising Futhark context... "
 val devices = String.fields (fn c => c = #",") (CLA.parseString "devices" "")
 val ctx_set = CtxSet.fromList devices
-val (default_device, default_ctx) = Seq.first ctx_set
+val default_device = 0
+val default_ctx = CtxSet.choose ctx_set default_device
 val () = print "Done!\n"
 
 

--- a/dep/CTX_SET.sml
+++ b/dep/CTX_SET.sml
@@ -1,11 +1,12 @@
 signature CTX_SET =
 sig
   type device_identifier = Device.device_identifier
+  type gpu_identifier = Device.gpu_identifier
   type ctx
-  type ctx_set = (device_identifier * ctx) Seq.t
+  type ctx_set = (gpu_identifier * ctx) Seq.t
   type t = ctx_set
 
-  val fromList: device_identifier list -> ctx_set
+  val fromList: gpu_identifier list -> ctx_set
   val choose: ctx_set -> device_identifier -> ctx
   val toCtxList: ctx_set -> ctx list
   val free: ctx_set -> unit

--- a/dep/CtxSet.sml
+++ b/dep/CtxSet.sml
@@ -40,10 +40,10 @@ struct
   val logging = CommandLineArgs.parseFlag "logging"
 
   type ctx = F.ctx
-  type ctx_set = (device_identifier * F.ctx) Seq.t
+  type ctx_set = (gpu_identifier * F.ctx) Seq.t
   type t = ctx_set
 
-  fun fromList (devices: device_identifier list) =
+  fun fromList (devices: gpu_identifier list) =
     Seq.map
       (fn device =>
          let
@@ -65,8 +65,10 @@ struct
 
   fun choose (ctxSet: ctx_set) (device: device_identifier) =
     let
-      val (device, ctx) = Seq.first
-        (Seq.filter (fn (d, _) => d = device) ctxSet)
+    (* val () = print ("device is " ^ device ^ "\n") *)
+    val (_, ctx) = Seq.nth ctxSet device
+      (* val (device, ctx) = Seq.first
+        (Seq.filter (fn (d, _) => d = device) ctxSet) *)
       (*val _ = print ("chosen device: " ^ device ^ "\n")*)
     in
       ctx

--- a/dep/Device.sml
+++ b/dep/Device.sml
@@ -1,4 +1,5 @@
 structure Device =
 struct
-  type device_identifier = string
+  type device_identifier = int
+  type gpu_identifier = string
 end

--- a/dep/GpuData.sml
+++ b/dep/GpuData.sml
@@ -2,9 +2,9 @@
 
 structure GpuData:
 sig
-  type 'a gpu_data = (Device.device_identifier * 'a) Seq.t
+  type 'a gpu_data = (Device.gpu_identifier * 'a) Seq.t
   type 'a t = 'a gpu_data
-  val initialize: (Device.device_identifier * 'ctx) Seq.t
+  val initialize: (Device.gpu_identifier * 'ctx) Seq.t
                   -> ('ctx -> 'a)
                   -> 'a gpu_data
   val free: 'a gpu_data -> ('a -> unit) -> unit
@@ -13,7 +13,7 @@ end =
 struct
   open Device
 
-  type 'a gpu_data = (device_identifier * 'a) Seq.t
+  type 'a gpu_data = (gpu_identifier * 'a) Seq.t
   type 'a t = 'a gpu_data
 
   fun initialize ctxSet f =
@@ -27,6 +27,7 @@ struct
     in ()
     end
 
-  fun choose data device =
-    #2 (Seq.first (Seq.filter (fn (d, _) => d = device) data))
+  fun choose (data: 'a gpu_data) device =
+    #2 (Seq.nth data device)
+    (* #2 (Seq.first (Seq.filter (fn (d, _) => d = device) data)) *)
 end


### PR DESCRIPTION
This is the second PR for the bug fix to enable multi stream on GPU. This is done by distinguishing between the Futhark context identifier (device_identifier in code) and gpu_identifier which refers to the number associated with the GPU according to CUDA.

Potentially, renaming device_identifier to context_identifier might be better for clarity.